### PR TITLE
remove unused 'let stream' as it prevents access to window.stream

### DIFF
--- a/js/resolutionScan.js
+++ b/js/resolutionScan.js
@@ -10,7 +10,6 @@
 let video = $('#video')[0],     //where we will put & test our video output
     deviceList = $('#devices')[0],          //device list dropdown
     devices = [],                        //getSources object to hold various camera options
-    stream,
     selectedCamera = [],            //used to hold a camera's ID and other parameters
     tests,                          //holder for our test results
     r = 0,                          //used for iterating through the array


### PR DESCRIPTION
The `let stream` declaration at the start adds the `stream` variable to the script's scope. Unfortunately, this means that all references to `stream` such as in [gum()](https://github.com/mikeybanez/WebRTC-Camera-Resolution/blob/a5886eff08b96df5958792a52c4aa58b88f0f730/js/resolutionScan.js#L158) do not refer to the intended `window.stream`.

In this case, this creates a critical bug where the `MediaStreamTrack` of the camera is never correctly stopped, which appears to be a necessary step considering how the page already calls `getUserMedia()` on startup. This results in an `OverconstrainedError` for all subsequent `getUserMedia(constraints)` calls, which essentially makes all the resolution tests erroneous.