### PR TITLE
navigator.getUserMedia is deprecated (and doesn't work on ios)

### DIFF
--- a/js/resolutionScan.js
+++ b/js/resolutionScan.js
@@ -42,7 +42,7 @@ $(document).ready(() => {
 
     console.log("adapter.js says this is " + adapter.browserDetails.browser + " " + adapter.browserDetails.version);
 
-    if (!navigator.getUserMedia) {
+    if (!navigator.mediaDevices.getUserMedia) {
         alert('You need a browser that supports WebRTC');
         $("div").hide();
         return;


### PR DESCRIPTION
navigator.getUserMedia is deprecated and should not be used.

navigator.getUserMedia only seems to be used in the initial check here.
Later, it is correctly used as navigator.mediaDevices.getUserMedia in stead

simply updating the initial check fixes this. (tested on ipad)

My guess would be that this was not updated by accident